### PR TITLE
PETA-78 implement user login api with PASETO token

### DIFF
--- a/api/account_test.go
+++ b/api/account_test.go
@@ -103,7 +103,7 @@ var _ = Describe("API tests", func() {
 				tc.buildStubs(store)
 
 				// start test server and send request
-				server := NewServer(store)
+				server := newTestServer(store)
 				recorder := httptest.NewRecorder()
 
 				url := fmt.Sprintf("/accounts/%d", tc.accountID)
@@ -213,7 +213,7 @@ var _ = Describe("API tests", func() {
 				tc.buildStubs(store)
 
 				// start test server and send request
-				server := NewServer(store)
+				server := newTestServer(store)
 				recorder := httptest.NewRecorder()
 
 				url := "/accounts"
@@ -342,7 +342,7 @@ var _ = Describe("API tests", func() {
 				tc.buildStubs(store)
 
 				// start test server and send request
-				server := NewServer(store)
+				server := newTestServer(store)
 				recorder := httptest.NewRecorder()
 
 				body, err := json.Marshal(tc.body)

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -1,10 +1,26 @@
 package api
 
 import (
+	db "github.com/Petatron/bank-simulator-backend/db/sqlc"
+	"github.com/Petatron/bank-simulator-backend/db/util"
 	"github.com/gin-gonic/gin"
 	"os"
 	"testing"
+	"time"
 )
+
+func newTestServer(store db.Store) *Server {
+	config := util.Config{
+		TokenSymmetricKey: util.GetRandomStringWithLength(32),
+		AccessToken:       time.Minute,
+	}
+	server, err := NewServer(config, store)
+	if err != nil {
+		panic(err)
+	}
+
+	return server
+}
 
 func TestMain(m *testing.M) {
 	gin.SetMode(gin.TestMode)

--- a/api/server.go
+++ b/api/server.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"fmt"
 	db "github.com/Petatron/bank-simulator-backend/db/sqlc"
+	"github.com/Petatron/bank-simulator-backend/db/util"
+	"github.com/Petatron/bank-simulator-backend/token"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/go-playground/validator/v10"
@@ -9,19 +12,29 @@ import (
 
 // Server serves HTTP requests for our banking service.
 type Server struct {
-	store  db.Store
-	router *gin.Engine
+	config     util.Config
+	store      db.Store
+	tokenMaker token.Maker
+	router     *gin.Engine
 }
 
 // NewServer creates a new HTTP server and set up routing.
-func NewServer(store db.Store) *Server {
-	server := &Server{store: store}
+func NewServer(config util.Config, store db.Store) (*Server, error) {
+	tokenMaker, err := token.NewPasetoMaker(config.TokenSymmetricKey)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create token maker: %w ", err)
+	}
 
+	server := &Server{
+		config:     config,
+		store:      store,
+		tokenMaker: tokenMaker,
+	}
 	// Set up currency validation
 	if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
 		err := v.RegisterValidation("currency", validCurrency)
 		if err != nil {
-			return nil
+			return nil, nil
 		}
 	}
 
@@ -36,7 +49,7 @@ func NewServer(store db.Store) *Server {
 
 	server.router = route
 
-	return server
+	return server, nil
 }
 
 // Start runs the HTTP server on a specific address.

--- a/api/server.go
+++ b/api/server.go
@@ -38,9 +38,17 @@ func NewServer(config util.Config, store db.Store) (*Server, error) {
 		}
 	}
 
+	server.setupRouter()
+
+	return server, nil
+}
+
+// setupRouter sets up all the routes for the HTTP server.
+func (server *Server) setupRouter() {
 	route := gin.Default()
 
 	route.POST("/users", server.createUser)
+	route.POST("/users/login", server.loginUser)
 	route.POST("/accounts", server.createAccount)
 	route.GET("/accounts/:id", server.getAccount)
 	route.GET("/accounts", server.listAccount)
@@ -48,8 +56,6 @@ func NewServer(config util.Config, store db.Store) (*Server, error) {
 	route.POST("/transfers", server.createTransfer)
 
 	server.router = route
-
-	return server, nil
 }
 
 // Start runs the HTTP server on a specific address.

--- a/api/transfer_test.go
+++ b/api/transfer_test.go
@@ -214,7 +214,7 @@ var _ = Describe("API tests", func() {
 				tc.buildStubs(store)
 
 				// start test server and send request
-				server := NewServer(store)
+				server := newTestServer(store)
 				recorder := httptest.NewRecorder()
 
 				body, err := json.Marshal(tc.body)

--- a/api/user.go
+++ b/api/user.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"database/sql"
 	"errors"
 	db "github.com/Petatron/bank-simulator-backend/db/sqlc"
 	"github.com/Petatron/bank-simulator-backend/db/util"
@@ -17,13 +18,24 @@ type createUserRequest struct {
 	Email    string `json:"email" binding:"required,email"`
 }
 
-// createUserResponse defines the response body for createUser API that hides the password to the user
-type createUserResponse struct {
+// userResponse defines the response body for createUser API that hides the password to the user
+type userResponse struct {
 	Username          string    `json:"username"`
 	FullName          string    `json:"full_name"`
 	Email             string    `json:"email"`
 	PasswordChangedAt time.Time `json:"password_changed_at"`
 	CreatedAt         time.Time `json:"created_at"`
+}
+
+// newUserResponse creates a new userResponse that hides the password to the user
+func newUserResponse(user db.User) userResponse {
+	return userResponse{
+		Username:          user.Username,
+		FullName:          user.FullName,
+		Email:             user.Email,
+		PasswordChangedAt: user.PasswordChangedAt,
+		CreatedAt:         user.CreatedAt,
+	}
 }
 
 // createUser implements the API that creates a new user
@@ -60,12 +72,56 @@ func (server *Server) createUser(ctx *gin.Context) {
 		return
 	}
 
-	rsp := createUserResponse{
-		Username:          user.Username,
-		FullName:          user.FullName,
-		Email:             user.Email,
-		PasswordChangedAt: user.PasswordChangedAt,
-		CreatedAt:         user.CreatedAt,
+	rsp := newUserResponse(user)
+
+	ctx.JSON(http.StatusOK, rsp)
+}
+
+// loginUserRequest defines the request body for loginUser API
+type loginUserRequest struct {
+	Username string `json:"username" binding:"required,alphanum"`
+	Password string `json:"password" binding:"required,min=6"`
+}
+
+// loginUserResponse defines the response body for loginUser API
+type loginUserResponse struct {
+	AccessToken string       `json:"access_token"`
+	User        userResponse `json:"user"`
+}
+
+// loginUser implements the API that logs in a user
+func (server *Server) loginUser(ctx *gin.Context) {
+	var req loginUserRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, errorResponse(err))
+		return
+	}
+
+	user, err := server.store.GetUser(ctx, req.Username)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			ctx.JSON(http.StatusBadRequest, errorResponse(err))
+			return
+		}
+		ctx.JSON(http.StatusUnauthorized, errorResponse(err))
+		return
+	}
+
+	err = util.CheckPassword(req.Password, user.HashedPassword)
+	if err != nil {
+		ctx.JSON(http.StatusUnauthorized, errorResponse(err))
+		return
+	}
+
+	accessToken, err := server.tokenMaker.CreateToken(user.Username, server.config.AccessToken)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
+		return
+	}
+
+	rsp := loginUserResponse{
+		AccessToken: accessToken,
+		User:        newUserResponse(user),
 	}
 
 	ctx.JSON(http.StatusOK, rsp)

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -166,7 +166,7 @@ var _ = Describe("API tests", func() {
 				tc.buildStubs(store)
 
 				// start test server and send request
-				server := NewServer(store)
+				server := newTestServer(store)
 				recorder := httptest.NewRecorder()
 
 				body, err := json.Marshal(tc.body)

--- a/app.env
+++ b/app.env
@@ -1,3 +1,5 @@
 DB_DRIVER=postgres
 DB_SOURCE=postgresql://root:password@localhost:5432/bank_simulator?sslmode=disable
 SERVER_ADDRESS=0.0.0.0:8080
+TOKEN_SYMMETRIC_KEY=12345678901234567890123456789012
+ACCESS_TOKEN_DURATION=15m

--- a/db/util/config.go
+++ b/db/util/config.go
@@ -1,12 +1,17 @@
 package util
 
-import "github.com/spf13/viper"
+import (
+	"github.com/spf13/viper"
+	"time"
+)
 
 // Config defines the configuration structure for the application
 type Config struct {
-	DBDriver      string `mapstructure:"DB_DRIVER"`
-	DBSource      string `mapstructure:"DB_SOURCE"`
-	ServerAddress string `mapstructure:"SERVER_ADDRESS"`
+	DBDriver          string        `mapstructure:"DB_DRIVER"`
+	DBSource          string        `mapstructure:"DB_SOURCE"`
+	ServerAddress     string        `mapstructure:"SERVER_ADDRESS"`
+	TokenSymmetricKey string        `mapstructure:"TOKEN_SYMMETRIC_KEY"`
+	AccessToken       time.Duration `mapstructure:"ACCESS_TOKEN_DURATION"`
 }
 
 // LoadConfig loads the configuration from file and environment variables

--- a/main.go
+++ b/main.go
@@ -21,7 +21,10 @@ func main() {
 	}
 
 	store := db.NewStore(conn)
-	server := api.NewServer(store)
+	server, err := api.NewServer(config, store)
+	if err != nil {
+		log.Fatal("Cannot create server with error: ", err)
+	}
 
 	err = server.Start(config.ServerAddress)
 	if err != nil {

--- a/token/paseto_maker.go
+++ b/token/paseto_maker.go
@@ -10,17 +10,17 @@ import (
 // PasetoMaker is a PASETO token maker
 type PasetoMaker struct {
 	paseto       *paseto.V2
-	symmetrickey []byte
+	symmetricKey []byte
 }
 
 // NewPasetoMaker creates a new PasetoMaker
-func NewPasetoMaker(symmetrickey string) (Maker, error) {
-	if len(symmetrickey) != chacha20poly1305.KeySize {
+func NewPasetoMaker(SymmetricKey string) (Maker, error) {
+	if len(SymmetricKey) != chacha20poly1305.KeySize {
 		return nil, fmt.Errorf("invalid key size: must be exactly %d characters", chacha20poly1305.KeySize)
 	}
 	maker := &PasetoMaker{
 		paseto:       paseto.NewV2(),
-		symmetrickey: []byte(symmetrickey),
+		symmetricKey: []byte(SymmetricKey),
 	}
 	return maker, nil
 }
@@ -32,14 +32,14 @@ func (maker *PasetoMaker) CreateToken(username string, duration time.Duration) (
 		return "", err
 	}
 
-	return maker.paseto.Encrypt(maker.symmetrickey, payload, nil)
+	return maker.paseto.Encrypt(maker.symmetricKey, payload, nil)
 }
 
 // VerifyToken checks if the token is valid or not
 func (maker *PasetoMaker) VerifyToken(token string) (*Payload, error) {
 	payload := &Payload{}
 
-	err := maker.paseto.Decrypt(token, maker.symmetrickey, payload, nil)
+	err := maker.paseto.Decrypt(token, maker.symmetricKey, payload, nil)
 	if err != nil {
 		return nil, ErrExpiredToken
 	}


### PR DESCRIPTION
- Update `config` file with `accessToken` and `durationTime`. Add `config` setting into server struct.
- Update UT to reflect the new update for config parameter in server struct.
- Update `userResponse` to hide the password to user and make it reuse-able in other function.
- Implement `loginUser` API with response struct.