### PR TITLE
PETA-85 implement auth middleware and rules with Gin

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -25,11 +25,6 @@ func (server *Server) createAccount(ctx *gin.Context) {
 		return
 	}
 
-	if !req.Currency.IsValid() {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid currency"})
-		return
-	}
-
 	// createAccount API rule: A logged-in user can only create an account for themselves
 	authPayload := ctx.MustGet(authorizationPayloadKey).(*token.Payload)
 	arg := db.CreateAccountParams{

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"errors"
+	"github.com/Petatron/bank-simulator-backend/token"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"strings"
+)
+
+const (
+	authorizationHeaderKey  = "authorization"
+	authorizationTypeBearer = "bearer"
+	authorizationPayloadKey = "authorization_payload"
+)
+
+func authMiddleware(tokenMaker token.Maker) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		authorizationHeader := ctx.GetHeader(authorizationHeaderKey)
+
+		if len(authorizationHeader) == 0 {
+			err := errors.New("authorization header is not provided")
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, errorResponse(err))
+			return
+		}
+
+		files := strings.Fields(authorizationHeader)
+
+		if len(files) != 2 {
+			err := errors.New("invalid authorization header format")
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, errorResponse(err))
+			return
+		}
+
+		authorizationType := strings.ToLower(files[0])
+
+		if authorizationType != authorizationTypeBearer {
+			err := errors.New("authorization type is not supported")
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, errorResponse(err))
+			return
+		}
+
+		accessToken := files[1]
+		payload, err := tokenMaker.VerifyToken(accessToken)
+		if err != nil {
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, errorResponse(err))
+			return
+		}
+
+		ctx.Set(authorizationPayloadKey, payload)
+		ctx.Next()
+	}
+
+}

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"fmt"
+	"github.com/Petatron/bank-simulator-backend/token"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func addAuthorization(
+	t *testing.T,
+	request *http.Request,
+	tokenMaker token.Maker,
+	authorizationType, username string,
+	duration time.Duration,
+) {
+	resultToken, err := tokenMaker.CreateToken(username, duration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorizationHeader := fmt.Sprintf("%s %s", authorizationType, resultToken)
+	request.Header.Set(authorizationHeaderKey, authorizationHeader)
+}
+
+func TestAuthMiddleware(t *testing.T) {
+	testCases := []struct {
+		name          string
+		setupAuth     func(t *testing.T, request *http.Request, tokenMaker token.Maker)
+		checkResponse func(t *testing.T, recorder *httptest.ResponseRecorder)
+	}{
+		{
+			name: "OK",
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, authorizationTypeBearer, "test", time.Minute)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				if recorder.Code != http.StatusOK {
+					t.Errorf("response code should be %d, but got %d", http.StatusOK, recorder.Code)
+				}
+			},
+		},
+
+		{
+			name: "NoAuthorization",
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				if recorder.Code != http.StatusUnauthorized {
+					t.Errorf("response code should be %d, but got %d", http.StatusUnauthorized, recorder.Code)
+				}
+			},
+		},
+
+		{
+			name: "UnsupportedAuthorizationType",
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, "unsupported", "test", time.Minute)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				if recorder.Code != http.StatusUnauthorized {
+					t.Errorf("response code should be %d, but got %d", http.StatusUnauthorized, recorder.Code)
+				}
+			},
+		},
+
+		{
+			name: "InvalidAuthorizationFormat",
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, "", "test", time.Minute)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				if recorder.Code != http.StatusUnauthorized {
+					t.Errorf("response code should be %d, but got %d", http.StatusUnauthorized, recorder.Code)
+				}
+			},
+		},
+
+		{
+			name: "InvalidToken",
+			setupAuth: func(t *testing.T, request *http.Request, tokenMaker token.Maker) {
+				addAuthorization(t, request, tokenMaker, authorizationTypeBearer, "test", -time.Minute)
+			},
+			checkResponse: func(t *testing.T, recorder *httptest.ResponseRecorder) {
+				if recorder.Code != http.StatusUnauthorized {
+					t.Errorf("response code should be %d, but got %d", http.StatusUnauthorized, recorder.Code)
+				}
+			},
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			server := newTestServer(nil)
+			server.router.GET(
+				"/test-auth",
+				authMiddleware(server.tokenMaker),
+				func(ctx *gin.Context) {
+					ctx.JSON(http.StatusOK, gin.H{})
+				})
+
+			request, err := http.NewRequest(http.MethodGet, "/test-auth", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tc.setupAuth(t, request, server.tokenMaker)
+			server.router.ServeHTTP(recorder, request)
+			tc.checkResponse(t, recorder)
+		})
+	}
+
+}

--- a/api/server.go
+++ b/api/server.go
@@ -49,11 +49,14 @@ func (server *Server) setupRouter() {
 
 	route.POST("/users", server.createUser)
 	route.POST("/users/login", server.loginUser)
-	route.POST("/accounts", server.createAccount)
-	route.GET("/accounts/:id", server.getAccount)
-	route.GET("/accounts", server.listAccount)
-	route.DELETE("/accounts/:id", server.deleteAccount)
-	route.POST("/transfers", server.createTransfer)
+
+	authRoutes := route.Group("/").Use(authMiddleware(server.tokenMaker))
+
+	authRoutes.POST("/accounts", server.createAccount)
+	authRoutes.GET("/accounts/:id", server.getAccount)
+	authRoutes.GET("/accounts", server.listAccount)
+	authRoutes.DELETE("/accounts/:id", server.deleteAccount)
+	authRoutes.POST("/transfers", server.createTransfer)
 
 	server.router = route
 }

--- a/api/transfer.go
+++ b/api/transfer.go
@@ -35,7 +35,7 @@ func (server *Server) createTransfer(ctx *gin.Context) {
 	authPayload := ctx.MustGet(authorizationPayloadKey).(*token.Payload)
 	if fromAccount.Owner != authPayload.Username {
 		err := errors.New("the account does not belong to the authenticated user")
-		ctx.JSON(http.StatusForbidden, errorResponse(err))
+		ctx.JSON(http.StatusUnauthorized, errorResponse(err))
 		return
 	}
 	_, valid = server.validAccount(ctx, req.ToAccountID, req.Currency)

--- a/api/transfer.go
+++ b/api/transfer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	db "github.com/Petatron/bank-simulator-backend/db/sqlc"
 	m "github.com/Petatron/bank-simulator-backend/model"
+	"github.com/Petatron/bank-simulator-backend/token"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
@@ -25,14 +26,24 @@ func (server *Server) createTransfer(ctx *gin.Context) {
 		return
 	}
 
-	if !server.validAccount(ctx, req.FromAccountID, req.Currency) {
+	fromAccount, valid := server.validAccount(ctx, req.FromAccountID, req.Currency)
+	if !valid {
 		return
 	}
 
-	if !server.validAccount(ctx, req.ToAccountID, req.Currency) {
+	// createTransfer API rule: A logged-in user can only create a transfer for the accounts they own
+	authPayload := ctx.MustGet(authorizationPayloadKey).(*token.Payload)
+	if fromAccount.Owner != authPayload.Username {
+		err := errors.New("the account does not belong to the authenticated user")
+		ctx.JSON(http.StatusForbidden, errorResponse(err))
+		return
+	}
+	_, valid = server.validAccount(ctx, req.ToAccountID, req.Currency)
+	if !valid {
 		return
 	}
 
+	// createTransfer API rule: A logged-in user can only create a transfer for the accounts they own
 	arg := db.TransferTxParams{
 		FromAccountID: req.FromAccountID,
 		ToAccountID:   req.ToAccountID,
@@ -49,21 +60,21 @@ func (server *Server) createTransfer(ctx *gin.Context) {
 }
 
 // validAccount checks if the given account is valid(availability, currency validation)
-func (server *Server) validAccount(ctx *gin.Context, accountID int64, currency m.CurrencyType) bool {
+func (server *Server) validAccount(ctx *gin.Context, accountID int64, currency m.CurrencyType) (db.Account, bool) {
 	account, err := server.store.GetAccount(ctx, accountID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			ctx.JSON(http.StatusNotFound, gin.H{"error": "this account is not found"})
-			return false
+			return account, false
 		}
 		ctx.JSON(http.StatusInternalServerError, errorResponse(err))
-		return false
+		return account, false
 	}
 
 	if account.Currency != string(currency) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "account currency does not match or incorrect"})
-		return false
+		return account, false
 	}
 
-	return true
+	return account, true
 }

--- a/db/query/account.sql
+++ b/db/query/account.sql
@@ -13,10 +13,10 @@ WHERE id = $1 LIMIT 1;
 
 -- name: ListAccounts :many
 SELECT * FROM accounts
+WHERE owner = $1
 ORDER BY id
-LIMIT $1
-OFFSET $2;
-;
+LIMIT $2
+OFFSET $3;
 
 -- name: UpdateAccount :one
 UPDATE accounts

--- a/db/sqlc/account.sql.go
+++ b/db/sqlc/account.sql.go
@@ -110,18 +110,20 @@ func (q *Queries) GetAccountForUpdate(ctx context.Context, id int64) (Account, e
 
 const listAccounts = `-- name: ListAccounts :many
 SELECT id, owner, balance, currency, created_at FROM accounts
+WHERE owner = $1
 ORDER BY id
-LIMIT $1
-OFFSET $2
+LIMIT $2
+OFFSET $3
 `
 
 type ListAccountsParams struct {
-	Limit  int32 `json:"limit"`
-	Offset int32 `json:"offset"`
+	Owner  string `json:"owner"`
+	Limit  int32  `json:"limit"`
+	Offset int32  `json:"offset"`
 }
 
 func (q *Queries) ListAccounts(ctx context.Context, arg ListAccountsParams) ([]Account, error) {
-	rows, err := q.db.QueryContext(ctx, listAccounts, arg.Limit, arg.Offset)
+	rows, err := q.db.QueryContext(ctx, listAccounts, arg.Owner, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}

--- a/db/sqlc/account_test.go
+++ b/db/sqlc/account_test.go
@@ -117,7 +117,8 @@ var _ = Describe("Operation", func() {
 			testBalance := util.GetRandomMoneyAmount()
 			testCurrency := util.GetRandomCurrency()
 			arg1 := ListAccountsParams{
-				Limit:  2,
+				Owner:  testOwnerName.Username,
+				Limit:  5,
 				Offset: 0,
 			}
 


### PR DESCRIPTION
- Create Middleware for sensitive user operation API requests. The `Middleware` allows the server to check and authorize input information for security. If the request is unauthorized, it will call `ctx.Abort()` to prevent the request. Otherwise, it will create a handler `createAccount(ctx)` to forward a real handler with auth token.
- Create `setupRouter()` for adding all API calls with `Middleware` handler in the server.
- Update `account.sql` to add the account’s user name for auth purposes.
- Update account and transfer UT with middleware auth